### PR TITLE
JIP-79-환경-구성-변경

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["custom"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,8 @@
     "react-dom": "18.2.0",
     "react-native-web": "^0.18.12",
     "typescript": "4.9.5",
-    "ui": "*"
+    "ui": "*",
+    "eslint-config-custom": "*",
+    "tsconfig": "*"
   }
 }


### PR DESCRIPTION
npm run lint를 하였을 때 web의 next/core-web-vitals와 eslint-config-custom의 eslint-config-next의 충돌을 확인하여 코드 수정

JIP-79

# PR

## 🗄️ 종류

PR 종류를 선택하세요

- [ ] Code Review
- [ ] New Feature
- [ ] Remove Feature
- [ ] Change Logic
- [x] Bug Fix
- [x] Setup

<br>

## 🔍 왜 변경을 했습니까?

- 루트 디렉토리에서 npm run lint를 하였을 때 플러그인 충돌을 확인할 수 있었습니다.<br/> 이는 apps/web/.eslintrc.json의 @next/next/core-web-vitals와 최상단 루트디렉토리 eslintrc.js의 eslint-config-next의 plugin:@next/next/recommended이 충돌한다는 것을 알 수 있었습니다.<br/>이를 수정하기 위해 internal Package인 eslint-config-custom 워크스페이스의 eslint-config-custom를 사용하기 위해 ```"eslint-config-custom":"*"```를 apps/web/package.json에 추가했습니다.
- apps/web/tsconfig.json에서  ``` "extends": "tsconfig/nextjs.json",```을 보고 internal Package를 쓴다는 것으로 이해하였습니다.<br/> 하지만 apps/web/package.json의 dependencies에서 명시되있지 않아 ```"tsconfig": "*"```을 추가했습니다.


<br>

## 🔧 작업 내용
- apps/web/.eslintrc.json의 ```"extends": "next/core-web-vitals" => "extends": ["custom"]```
- apps/web/package.json의 dependencies에  ``` "eslint-config-custom": "*",
    "tsconfig": "*"``` 추가

<br>

## 📷 스크린샷
### eslint 플러그인 충돌
<img width="2111" alt="스크린샷 2023-02-06 오전 1 29 46" src="https://user-images.githubusercontent.com/46583212/216833141-413640a1-a470-4515-bdf4-d0b09a4e27b4.png">
### 코드 변경 후의 결과
<img width="614" alt="스크린샷 2023-02-06 오전 1 29 20" src="https://user-images.githubusercontent.com/46583212/216833200-82d62372-b656-4a52-baab-987a766c1f4f.png">


<br>

## 📝 리뷰할 때 참고할 점

- Internal Package에 대해서는 터보레포의 [워크스페이스](https://turbo.build/repo/docs/handbook/workspaces) 와 [Internal Package](https://turbo.build/repo/docs/handbook/sharing-code/internal-packages)를 참고하였습니다.
