### PR TITLE
Jip 2 api 연결 프론트

### DIFF
--- a/apps/native/.gitignore
+++ b/apps/native/.gitignore
@@ -12,3 +12,5 @@ web-build/
 
 # macOS
 .DS_Store
+
+.env

--- a/apps/native/app.config.ts
+++ b/apps/native/app.config.ts
@@ -1,0 +1,13 @@
+import 'dotenv/config'
+
+export interface AppConfig {
+  OAUTH_KAKAO_URI: string
+}
+
+export default {
+  extra: {
+    OAUTH_KAKAO_URI: process.env.OAUTH_KAKAO_URI,
+  },
+  name: 'Jipangs',
+  version: '1.0.0',
+}

--- a/apps/native/config.ts
+++ b/apps/native/config.ts
@@ -1,0 +1,5 @@
+import Constants from 'expo-constants'
+
+import { AppConfig } from 'app.config'
+
+export const { OAUTH_KAKAO_URI } = Constants.manifest?.extra as AppConfig

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/native": "^11.10.0",
     "@emotion/react": "^11.10.5",
+    "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-navigation/bottom-tabs": "^6.5.7",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/native-stack": "^6.9.12",
     "@reduxjs/toolkit": "^1.9.3",
     "expo": "^48.0.5",
+    "expo-constants": "^14.2.1",
     "expo-font": "^11.1.1",
     "expo-image": "^1.0.0",
     "expo-sharing": "^11.2.2",
@@ -39,6 +40,7 @@
     "@types/react-native": "~0.70.6",
     "@types/react-redux": "^7.1.25",
     "babel-plugin-module-resolver": "^5.0.0",
+    "dotenv": "^16.0.3",
     "eslint-config-custom": "*",
     "tsconfig": "*"
   },

--- a/apps/native/src/App.tsx
+++ b/apps/native/src/App.tsx
@@ -1,30 +1,14 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { NavigationContainer } from '@react-navigation/native'
-import { useEffect } from 'react'
 import { Text } from 'react-native'
 
 import useLoadFonts from './hooks/useLoadFonts'
-import { useAppDispatch } from './redux/hooks'
-import { login } from './redux/reducers/authReducer'
-import { store } from './redux/store'
+import useUpdateAuth from './hooks/useUpdateAuth'
 import Routes from './routes/Routes'
-import { setAuthInfo, getAuthInfo } from './utils/asyncStorage'
-
-store.subscribe(() => {
-  const { auth } = store.getState()
-  setAuthInfo(auth)
-})
 
 export default function Native() {
-  const dispatch = useAppDispatch()
   const [isFontsLoaded] = useLoadFonts()
-
-  useEffect(() => {
-    getAuthInfo().then((authInfo) => {
-      if (!authInfo) return
-      dispatch(login(authInfo))
-    })
-  }, [dispatch])
+  useUpdateAuth()
 
   if (!isFontsLoaded) return <Text>폰트 로딩중</Text>
 

--- a/apps/native/src/App.tsx
+++ b/apps/native/src/App.tsx
@@ -12,9 +12,7 @@ import { setAuthInfo, getAuthInfo } from './utils/asyncStorage'
 
 store.subscribe(() => {
   const { auth } = store.getState()
-  ;(async () => {
-    await setAuthInfo(auth)
-  })()
+  setAuthInfo(auth)
 })
 
 export default function Native() {

--- a/apps/native/src/App.tsx
+++ b/apps/native/src/App.tsx
@@ -1,11 +1,32 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { NavigationContainer } from '@react-navigation/native'
+import { useEffect } from 'react'
 import { Text } from 'react-native'
 
 import useLoadFonts from './hooks/useLoadFonts'
+import { useAppDispatch } from './redux/hooks'
+import { login } from './redux/reducers/authReducer'
+import { store } from './redux/store'
 import Routes from './routes/Routes'
+import { setAuthInfo, getAuthInfo } from './utils/asyncStorage'
+
+store.subscribe(() => {
+  const { auth } = store.getState()
+  ;(async () => {
+    await setAuthInfo(auth)
+  })()
+})
 
 export default function Native() {
+  const dispatch = useAppDispatch()
   const [isFontsLoaded] = useLoadFonts()
+
+  useEffect(() => {
+    getAuthInfo().then((authInfo) => {
+      if (!authInfo) return
+      dispatch(login(authInfo))
+    })
+  }, [dispatch])
 
   if (!isFontsLoaded) return <Text>폰트 로딩중</Text>
 

--- a/apps/native/src/constants/route-names.ts
+++ b/apps/native/src/constants/route-names.ts
@@ -2,6 +2,7 @@ export const ROUTE_NAMES = {
   EXTERNAL_LINK: 'ExternalLink',
   HOME: 'Home',
   LOGIN: 'Login',
+  LOGIN_WEBVIEW: 'LoginWebView',
   MAIN: 'Main',
   MYPAGE: 'Mypage',
   REGISTER: 'Register',

--- a/apps/native/src/hooks/useUpdateAuth.tsx
+++ b/apps/native/src/hooks/useUpdateAuth.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { useEffect, useRef } from 'react'
+
+import { useAppDispatch, useAppSelector } from '../redux/hooks'
+import { login } from '../redux/reducers/authReducer'
+import { Auth } from '../redux/types'
+import { getAuthInfo, setAuthInfo } from '../utils/asyncStorage'
+
+export default function useUpdateAuth() {
+  const dispatch = useAppDispatch()
+  const { auth } = useAppSelector((state) => state)
+  const authRef = useRef<Auth | null>(null)
+  const didMount = useRef(false)
+
+  useEffect(() => {
+    getAuthInfo().then((authInfo) => {
+      if (!authInfo) return
+      dispatch(login(authInfo))
+    })
+  }, [dispatch])
+
+  useEffect(() => {
+    if (didMount.current) {
+      if (authRef.current !== auth) {
+        setAuthInfo(auth)
+        authRef.current = auth
+      }
+    }
+    didMount.current = true
+  }, [auth])
+}

--- a/apps/native/src/redux/reducers/authReducer.ts
+++ b/apps/native/src/redux/reducers/authReducer.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-type Auth = { hasInfo: boolean; token: string }
+import { Auth } from '../types'
 
 const initialState = {
   hasInfo: false,

--- a/apps/native/src/redux/reducers/authReducer.ts
+++ b/apps/native/src/redux/reducers/authReducer.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-param-reassign */
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+type Auth = { hasInfo: boolean; token: string }
+
+const initialState = {
+  hasInfo: false,
+  token: '',
+}
+
+export const authSlice = createSlice({
+  initialState,
+  name: 'auth',
+  reducers: {
+    login: (state, action: PayloadAction<Auth>) => {
+      state.token = action.payload.token
+      state.hasInfo = action.payload.hasInfo
+    },
+    logout: (state) => {
+      state.token = ''
+      state.hasInfo = false
+    },
+  },
+})
+
+export const { login, logout } = authSlice.actions
+export default authSlice.reducer

--- a/apps/native/src/redux/store.ts
+++ b/apps/native/src/redux/store.ts
@@ -1,9 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit'
 
+import authReducer from './reducers/authReducer'
 import registerReducer from './reducers/registerReducer'
 
 export const store = configureStore({
-  reducer: { register: registerReducer },
+  reducer: { auth: authReducer, register: registerReducer },
 })
 
 export type RootState = ReturnType<typeof store.getState>

--- a/apps/native/src/redux/types.ts
+++ b/apps/native/src/redux/types.ts
@@ -102,3 +102,5 @@ export type EmailType = {
 export type MajorSpecificType = {
   majorSpecific: string
 }
+
+export type Auth = { hasInfo: boolean; token: string }

--- a/apps/native/src/routes/Routes.tsx
+++ b/apps/native/src/routes/Routes.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-useless-fragment */
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
 import { useAppSelector } from '../redux/hooks'
@@ -14,6 +15,19 @@ const STACK = createNativeStackNavigator<RootStackParamList>()
 function Routes() {
   const { hasInfo, token } = useAppSelector((state) => state.auth)
 
+  const screenWhenUserLoggedIn = hasInfo ? (
+    <>
+      <STACK.Screen
+        component={Main}
+        name="Main"
+        options={{ headerTitleAlign: 'center' }}
+      />
+      <STACK.Screen component={ExternalLink} name="ExternalLink" />
+    </>
+  ) : (
+    <STACK.Screen component={Register} name="Register" />
+  )
+
   return (
     <STACK.Navigator
       screenOptions={{
@@ -23,21 +37,7 @@ function Routes() {
       initialRouteName="Login"
     >
       {token ? (
-        <>
-          {' '}
-          {hasInfo ? (
-            <>
-              <STACK.Screen
-                component={Main}
-                name="Main"
-                options={{ headerTitleAlign: 'center' }}
-              />
-              <STACK.Screen component={ExternalLink} name="ExternalLink" />
-            </>
-          ) : (
-            <STACK.Screen component={Register} name="Register" />
-          )}
-        </>
+        screenWhenUserLoggedIn
       ) : (
         <>
           <STACK.Screen component={LoginWebView} name="LoginWebView" />

--- a/apps/native/src/routes/Routes.tsx
+++ b/apps/native/src/routes/Routes.tsx
@@ -1,5 +1,6 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
+import { useAppSelector } from '../redux/hooks'
 import ExternalLink from '../screens/external-link'
 import Login from '../screens/login'
 import LoginWebView from '../screens/login/WebView'
@@ -11,6 +12,8 @@ import Register from './RegisterRoutes'
 const STACK = createNativeStackNavigator<RootStackParamList>()
 
 function Routes() {
+  const { hasInfo, token } = useAppSelector((state) => state.auth)
+
   return (
     <STACK.Navigator
       screenOptions={{
@@ -19,15 +22,28 @@ function Routes() {
       }}
       initialRouteName="Login"
     >
-      <STACK.Screen component={Login} name="Login" />
-      <STACK.Screen component={Register} name="Register" />
-      <STACK.Screen
-        component={Main}
-        name="Main"
-        options={{ headerTitleAlign: 'center' }}
-      />
-      <STACK.Screen component={ExternalLink} name="ExternalLink" />
-      <STACK.Screen component={LoginWebView} name="LoginWebView" />
+      {token ? (
+        <>
+          {' '}
+          {hasInfo ? (
+            <>
+              <STACK.Screen
+                component={Main}
+                name="Main"
+                options={{ headerTitleAlign: 'center' }}
+              />
+              <STACK.Screen component={ExternalLink} name="ExternalLink" />
+            </>
+          ) : (
+            <STACK.Screen component={Register} name="Register" />
+          )}
+        </>
+      ) : (
+        <>
+          <STACK.Screen component={LoginWebView} name="LoginWebView" />
+          <STACK.Screen component={Login} name="Login" />
+        </>
+      )}
     </STACK.Navigator>
   )
 }

--- a/apps/native/src/routes/Routes.tsx
+++ b/apps/native/src/routes/Routes.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
 import ExternalLink from '../screens/external-link'
 import Login from '../screens/login'
+import LoginWebView from '../screens/login/WebView'
 import { RootStackParamList } from '../types'
 
 import Main from './HomeRoutes'
@@ -16,7 +17,7 @@ function Routes() {
         contentStyle: { backgroundColor: '#ffffff' },
         headerShown: false,
       }}
-      initialRouteName="Main"
+      initialRouteName="Login"
     >
       <STACK.Screen component={Login} name="Login" />
       <STACK.Screen component={Register} name="Register" />
@@ -26,6 +27,7 @@ function Routes() {
         options={{ headerTitleAlign: 'center' }}
       />
       <STACK.Screen component={ExternalLink} name="ExternalLink" />
+      <STACK.Screen component={LoginWebView} name="LoginWebView" />
     </STACK.Navigator>
   )
 }

--- a/apps/native/src/screens/login/WebView.tsx
+++ b/apps/native/src/screens/login/WebView.tsx
@@ -6,7 +6,6 @@ import { login } from '../../redux/reducers/authReducer'
 import { parseQueryString } from '../../utils/parseQuery'
 
 export default function LoginWebView() {
-  console.log(OAUTH_KAKAO_URI)
   const dispatch = useAppDispatch()
   const handleNavigationStateChange = (navigationState: WebViewNavigation) => {
     const queryObject = parseQueryString(navigationState.url)

--- a/apps/native/src/screens/login/WebView.tsx
+++ b/apps/native/src/screens/login/WebView.tsx
@@ -1,0 +1,25 @@
+import { WebView, WebViewNavigation } from 'react-native-webview'
+
+import { OAUTH_KAKAO_URI } from '../../../config'
+import { useAppDispatch } from '../../redux/hooks'
+import { login } from '../../redux/reducers/authReducer'
+import { parseQueryString } from '../../utils/parseQuery'
+
+export default function LoginWebView() {
+  console.log(OAUTH_KAKAO_URI)
+  const dispatch = useAppDispatch()
+  const handleNavigationStateChange = (navigationState: WebViewNavigation) => {
+    const queryObject = parseQueryString(navigationState.url)
+    if (!queryObject || !queryObject.token || !queryObject.hasInfo) return
+    const hasInfo = queryObject.hasInfo === 'true'
+    dispatch(login({ hasInfo, token: queryObject.token }))
+  }
+  return (
+    <WebView
+      source={{
+        uri: OAUTH_KAKAO_URI,
+      }}
+      onNavigationStateChange={handleNavigationStateChange}
+    />
+  )
+}

--- a/apps/native/src/screens/login/index.tsx
+++ b/apps/native/src/screens/login/index.tsx
@@ -1,13 +1,16 @@
 import Logo from '../../../assets/images/logo.png'
 import LogoText from '../../../assets/images/textLogo.png'
 import LoginButton from '../../features/login/components/Button'
+import type { StackScreenProps } from '../../types/navigation'
 
 import * as Styled from './styled'
 
 const blurhash =
   '|rF?hV%2WCj[ayj[a|j[az_NaeWBj@ayfRayfQfQM{M|azj[azf6fQfQfQIpWXofj[ayj[j[fQayWCoeoeaya}j[ayfQa{oLj?j[WVj[ayayj[fQoff7azayj[ayj[j[ayofayayayj[fQj[ayayj[ayfjj[j[ayjuayj['
 
-export default function LoginScreen() {
+export default function LoginScreen({ navigation }: StackScreenProps<'Login'>) {
+  const handleLoginPress = () => navigation.navigate('LoginWebView')
+
   return (
     <Styled.Screen>
       <Styled.LogoText
@@ -19,8 +22,7 @@ export default function LoginScreen() {
       <Styled.Logo contentFit="cover" placeholder={blurhash} source={Logo} />
       <Styled.GapWide />
       <Styled.ButtonContainer>
-        <LoginButton oauthProvider="kakao" onPress={() => {}} />
-        <LoginButton oauthProvider="apple" onPress={() => {}} />
+        <LoginButton oauthProvider="kakao" onPress={handleLoginPress} />
       </Styled.ButtonContainer>
     </Styled.Screen>
   )

--- a/apps/native/src/types/custom.d.ts
+++ b/apps/native/src/types/custom.d.ts
@@ -11,3 +11,7 @@ declare module '*.png' {
 }
 
 declare module '*.ttf'
+
+declare module 'react-native-dotenv' {
+  export const OAUTH_KAKAO_URI: string
+}

--- a/apps/native/src/types/navigation.ts
+++ b/apps/native/src/types/navigation.ts
@@ -9,6 +9,7 @@ export type RootStackParamList = {
   [ROUTE_NAMES.MAIN]: undefined
   [ROUTE_NAMES.LOGIN]: undefined
   [ROUTE_NAMES.REGISTER]: undefined
+  [ROUTE_NAMES.LOGIN_WEBVIEW]: undefined
 }
 
 export type RegisterStackParamList = {

--- a/apps/native/src/utils/asyncStorage.ts
+++ b/apps/native/src/utils/asyncStorage.ts
@@ -7,7 +7,12 @@ export const setAuthInfo = async (value: Auth) => {
     const jsonValue = JSON.stringify(value)
     await AsyncStorage.setItem('@storage_Key', jsonValue)
   } catch (e) {
-    // saving error
+    if (e instanceof Error) {
+      throw e
+    }
+    throw new Error('토큰을 async-storage에 저장하던 중 에러가 발생했습니다.', {
+      cause: e,
+    })
   }
 }
 
@@ -16,6 +21,14 @@ export const getAuthInfo = async () => {
     const jsonValue = await AsyncStorage.getItem('@storage_Key')
     return jsonValue != null ? (JSON.parse(jsonValue) as Auth) : null
   } catch (e) {
-    return null
+    if (e instanceof Error) {
+      throw e
+    }
+    throw new Error(
+      '토큰을 async-storage에서 불러오던 중 에러가 발생했습니다.',
+      {
+        cause: e,
+      }
+    )
   }
 }

--- a/apps/native/src/utils/asyncStorage.ts
+++ b/apps/native/src/utils/asyncStorage.ts
@@ -1,0 +1,21 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+import { Auth } from '../redux/types'
+
+export const setAuthInfo = async (value: Auth) => {
+  try {
+    const jsonValue = JSON.stringify(value)
+    await AsyncStorage.setItem('@storage_Key', jsonValue)
+  } catch (e) {
+    // saving error
+  }
+}
+
+export const getAuthInfo = async () => {
+  try {
+    const jsonValue = await AsyncStorage.getItem('@storage_Key')
+    return jsonValue != null ? (JSON.parse(jsonValue) as Auth) : null
+  } catch (e) {
+    return null
+  }
+}

--- a/apps/native/src/utils/parseQuery.ts
+++ b/apps/native/src/utils/parseQuery.ts
@@ -1,9 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/naming-convention */
 export const parseQueryString = (
   url: string
 ): null | { [key: string]: string } => {
-  const [_, queryString] = url.split('?')
+  const [, queryString] = url.split('?')
   if (!queryString) return null
   const keyValuePairStringsArray = queryString.split('&')
   const keyValuePairObject = keyValuePairStringsArray.reduce(

--- a/apps/native/src/utils/parseQuery.ts
+++ b/apps/native/src/utils/parseQuery.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/naming-convention */
+export const parseQueryString = (
+  url: string
+): null | { [key: string]: string } => {
+  const [_, queryString] = url.split('?')
+  if (!queryString) return null
+  const keyValuePairStringsArray = queryString.split('&')
+  const keyValuePairObject = keyValuePairStringsArray.reduce(
+    (prevVal, currentVal) => {
+      const [key, value] = currentVal.split('=')
+      return { ...prevVal, [key]: value }
+    },
+    {}
+  )
+  return keyValuePairObject
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4636,6 +4636,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
@@ -5347,7 +5352,7 @@ expo-asset@~8.9.0:
     path-browserify "^1.0.0"
     url-parse "^1.5.9"
 
-expo-constants@~14.2.0, expo-constants@~14.2.1:
+expo-constants@^14.2.1, expo-constants@~14.2.0, expo-constants@~14.2.1:
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-14.2.1.tgz#b5b6b8079d2082c31ccf2cbc7cf97a0e83c229c3"
   integrity sha512-DD5u4QmBds2U7uYo409apV7nX+XjudARcgqe7S9aRFJ/6kyftmuxvk1DpaU4X42Av8z/tfKwEpuxl+vl7HHx/Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,6 +2232,13 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
+"@react-native-async-storage/async-storage@^1.17.11":
+  version "1.17.11"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
+  integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-clean@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-10.1.1.tgz#4c73ce93a63a24d70c0089d4025daac8184ff504"
@@ -6661,6 +6668,11 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -7483,6 +7495,13 @@ meow@^8.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# PR

## 🗄️ 종류

PR 종류를 선택하세요

- [ ] Code Review
- [x] New Feature
- [ ] Remove Feature
- [ ] Change Logic
- [ ] Bug Fix
- [x] Setup

<br>

## 🔍 왜 변경을 했습니까?

- 로그인 기능을 구현하였습니다.
- 토큰등의 인증 정보를 리덕스와 asyncStorage에 저장하였습니다.

<br>

## 🔧 작업 내용

- @react-native-async-storage/async-storage, dotenv, expo-constants 설치
- 환경변수를 숨기기 위한 패키지 설치 -  .env을 사용하기 위해 `dotenv, expo-constants`을 설치하였습니다.
추가적으로 .env 파일의 내용을 가져오고 사용하기 위해

```
app.config.ts
config.ts
```
를 작성하고
`custom.d.ts`에
```
declare module 'react-native-dotenv' {
  export const OAUTH_KAKAO_URI: string
}
```
를 추가했습니다.
<br/>
- 인증정보를 저장하기 위한 슬라이스 작성
- 로그인 로직 작성
사용자가 버튼을 누르면 로그인을 위한 웹뷰 화면으로 라우팅됩니다.
후에 서버에서 주는 토큰과 회원정보입력여부를 리덕스에 저장합니다.
App.tsx에서는 스토어의 변화를 보고 async-storage에 인증정보를 업데이트 합니다.
```
store.subscribe(() => {
  const { auth } = store.getState()
  ;(async () => {
    await setAuthInfo(auth)
  })()
})
```
앱의 실행시에는 App.tsx의 마운트 후에 async-storage에 있는 값을 리덕스에 전달합니다.
```
  useEffect(() => {
    getAuthInfo().then((authInfo) => {
      if (!authInfo) return
      dispatch(login(authInfo))
    })
  }, [dispatch])
```
<br/>
- 쿼리스트링 파싱함수 작성 

```
export const parseQueryString = (
  url: string
): null | { [key: string]: string } => {
```

인증정보 파싱(token:string, hasInfo:boolean) 뿐만이 아닌 모든 쿼리스트링에 유니버셜하게 사용하고 싶어서 리턴 타입은 `{ [key: string]: string }`로 두었습니다.

<br>

## 📷 스크린샷

<br>

## 📝 리뷰할 때 참고할 점

- App.tsx에서 IIFE를 사용하기 위해 `/* eslint-disable @typescript-eslint/no-floating-promises */` 를 추가했습니다.
- protected routes는 [공식문서](https://reactnavigation.org/docs/auth-flow/)를 참고했습니다.
